### PR TITLE
Fix event listener removal

### DIFF
--- a/src/Breakpoint/Breakpoint.js
+++ b/src/Breakpoint/Breakpoint.js
@@ -13,19 +13,18 @@ class Breakpoint extends React.Component {
     this.extractBreakpointAndModifierFromProps = this.extractBreakpointAndModifierFromProps.bind(
       this
     );
+
+    this.handleResize = this.handleResize.bind(
+      this
+    );
   }
 
   componentDidMount() {
-    window.addEventListener('resize', () => {
-      this.setState({
-        width: BreakpointUtil.currentWidth,
-        currentBreakpoint: BreakpointUtil.currentBreakpointName
-      });
-    });
+    window.addEventListener('resize', this.handleResize);
   }
 
   componentWillUnmount() {
-    window.removeEventListener('resize', () => {}, true);
+    window.removeEventListener('resize', this.handleResize);
   }
 
   extractBreakpointAndModifierFromProps(allProps) {
@@ -44,6 +43,13 @@ class Breakpoint extends React.Component {
       breakpoint,
       modifier
     };
+  }
+  
+  handleResize() {
+    this.setState({
+      width: BreakpointUtil.currentWidth,
+      currentBreakpoint: BreakpointUtil.currentBreakpointName
+    });
   }
 
   render() {


### PR DESCRIPTION
While browsing this repo source code (cool idea btw 🙂 ) I noticed that an empty arrow function was being passed on the [event listener removal ](https://github.com/flexdinesh/react-socks/blob/master/src/Breakpoint/Breakpoint.js#L18). 

As per [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener), we should keep a reference to the function used on the `addEventListener` and use it on the removal.
Also, I guess there's no need to pass `true` as the last parameter of the removal since the we're not passing `true` when adding the event listener.

This PR aims to fix these two issues.

I also think that a throttling could be used when reacting to resizes, but I can do that on a different PR.

(PS: When running `npm i` or `npm test` I get the following error ` Requires Babel "^7.0.0-0", but was loaded with "6.26.3"....`. This is fixed by running `npx babel-upgrade --write`. I dit that locally so that I could run tests etc, but left it out of the PR since this may be some problem on my end.)