### PR TITLE
feat: moving listener to a context provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,10 @@ $ npm install --save react-socks
 ```
 
 ## Usage
+Just wrap your top level component with a `<BreakpointProvider >` component and use the `Breakpoint` anywhere you need.
 
 ```jsx
-import Breakpoint from 'react-socks';
+import { Breakpoint, BreakpointProvider} from 'react-socks';
 
 const Example = () => {
   return (
@@ -63,6 +64,12 @@ const Example = () => {
     </div>
   );
 };
+
+const App = () => (
+  <BreakpointProvider> 
+    <Example />
+  </BreakpointProvider> 
+);
 ```
 
 ## API

--- a/examples/Example.js
+++ b/examples/Example.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import Breakpoint from '../src/index';
+import { Breakpoint, BreakpointProvider } from '../src/index';
 // import { setDefaultBreakpoints } from '../src/index';
 // setDefaultBreakpoints([
 //   { xs: 0 },
@@ -9,6 +9,7 @@ import Breakpoint from '../src/index';
 //   { l: 769 },
 //   { xl: 1025 }
 // ]);
+
 class Example extends React.Component {
   constructor(props) {
     super(props);
@@ -18,44 +19,46 @@ class Example extends React.Component {
 
   render() {
     return (
-      <div>
-        <Breakpoint small down>
-          <div style={{ backgroundColor: '#0074D9' }}>
-            Hello World! small down
-          </div>
-        </Breakpoint>
-        <Breakpoint medium down>
-          <div style={{ backgroundColor: '#F012BE' }}>
-            Hello World! medium down
-          </div>
-        </Breakpoint>
-        <Breakpoint medium only>
-          <div style={{ backgroundColor: '#FFDC00' }}>
-            Hello World! medium only
-          </div>
-        </Breakpoint>
+      <BreakpointProvider>
+        <div>
+          <Breakpoint small down>
+            <div style={{ backgroundColor: '#0074D9' }}>
+              Hello World! small down
+            </div>
+          </Breakpoint>
+          <Breakpoint medium down>
+            <div style={{ backgroundColor: '#F012BE' }}>
+              Hello World! medium down
+            </div>
+          </Breakpoint>
+          <Breakpoint medium only>
+            <div style={{ backgroundColor: '#FFDC00' }}>
+              Hello World! medium only
+            </div>
+          </Breakpoint>
 
-        <Breakpoint medium up>
-          <div style={{ backgroundColor: '#2ECC40' }}>
-            Hello World! medium up
-          </div>
-        </Breakpoint>
-        <Breakpoint large down>
-          <div style={{ backgroundColor: '#FF851B' }}>
-            Hello World! large down
-          </div>
-        </Breakpoint>
-        <Breakpoint large up>
-          <div style={{ backgroundColor: '#39CCCC' }}>
-            Hello World! large up
-          </div>
-        </Breakpoint>
-        <Breakpoint xlarge only>
-          <div style={{ backgroundColor: '#FF4136' }}>
-            Hello World! xlarge only
-          </div>
-        </Breakpoint>
-      </div>
+          <Breakpoint medium up>
+            <div style={{ backgroundColor: '#2ECC40' }}>
+              Hello World! medium up
+            </div>
+          </Breakpoint>
+          <Breakpoint large down>
+            <div style={{ backgroundColor: '#FF851B' }}>
+              Hello World! large down
+            </div>
+          </Breakpoint>
+          <Breakpoint large up>
+            <div style={{ backgroundColor: '#39CCCC' }}>
+              Hello World! large up
+            </div>
+          </Breakpoint>
+          <Breakpoint xlarge only>
+            <div style={{ backgroundColor: '#FF4136' }}>
+              Hello World! xlarge only
+            </div>
+          </Breakpoint>
+        </div>
+      </BreakpointProvider>
     );
   }
 }

--- a/src/Breakpoint/Breakpoint.js
+++ b/src/Breakpoint/Breakpoint.js
@@ -1,30 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import BreakpointUtil from './breakpoint-util';
 
-class Breakpoint extends React.Component {
+import BreakpointUtil from './breakpoint-util';
+import { BreakpointContext } from './BreakpointProvider';
+
+export default class Breakpoint extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {
-      width: BreakpointUtil.currentWidth,
-      currentBreakpoint: BreakpointUtil.currentBreakpointName
-    };
 
     this.extractBreakpointAndModifierFromProps = this.extractBreakpointAndModifierFromProps.bind(
       this
     );
-
-    this.handleResize = this.handleResize.bind(
-      this
-    );
-  }
-
-  componentDidMount() {
-    window.addEventListener('resize', this.handleResize);
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener('resize', this.handleResize);
   }
 
   extractBreakpointAndModifierFromProps(allProps) {
@@ -44,24 +30,21 @@ class Breakpoint extends React.Component {
       modifier
     };
   }
-  
-  handleResize() {
-    this.setState({
-      width: BreakpointUtil.currentWidth,
-      currentBreakpoint: BreakpointUtil.currentBreakpointName
-    });
-  }
 
   render() {
     const { children, ...rest } = this.props;
     const { breakpoint, modifier } = this.extractBreakpointAndModifierFromProps(
       rest
     );
+    const { currentBreakpointName, currentWidth } = this.context;
 
     const shouldRender = BreakpointUtil.shouldRender({
       breakpointName: breakpoint,
-      modifier
+      modifier,
+      currentBreakpointName,
+      currentWidth,
     });
+
     if (!shouldRender) return null;
 
     return (
@@ -70,8 +53,12 @@ class Breakpoint extends React.Component {
   }
 }
 
+Breakpoint.contextType = BreakpointContext;
+
 Breakpoint.propTypes = {
-  children: PropTypes.node
+  children: PropTypes.node,
+  up: PropTypes.bool,
+  down: PropTypes.bool,
+  only: PropTypes.bool,
 };
 
-export default Breakpoint;

--- a/src/Breakpoint/Breakpoint.test.js
+++ b/src/Breakpoint/Breakpoint.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { shallow } from 'enzyme';
-import Breakpoint from 'index';
+import { shallow, mount } from 'enzyme';
+import { Breakpoint, BreakpointProvider } from 'index';
 import { BreakpointUtil } from './breakpoint-util';
 import sinon from 'sinon';
 
@@ -21,91 +21,111 @@ describe('Breakpoint - small', () => {
   });
 
   it('should render small only', () => {
-    let wrapper = shallow(
-      <Breakpoint small>
-        <span>render only between 576 and 768</span>
-      </Breakpoint>
+    let wrapper = mount(
+      <BreakpointProvider>
+        <Breakpoint small>
+          <span>render only between 576 and 768</span>
+        </Breakpoint>
+      </BreakpointProvider>
     );
-    expect(wrapper.children()).toHaveLength(1);
+    expect(wrapper.children().children()).toHaveLength(1);
 
-    wrapper = shallow(
-      <Breakpoint small only>
-        <span>render only between 576 and 768</span>
-      </Breakpoint>
+    wrapper = mount(
+      <BreakpointProvider>
+        <Breakpoint small only>
+          <span>render only between 576 and 768</span>
+        </Breakpoint>
+      </BreakpointProvider>
     );
-    expect(wrapper.children()).toHaveLength(1);
+    expect(wrapper.children().children()).toHaveLength(1);
   });
 
   it('should render small down', () => {
-    const wrapper = shallow(
-      <Breakpoint small down>
-        <span>render below 768</span>
-      </Breakpoint>
+    const wrapper = mount(
+      <BreakpointProvider>
+        <Breakpoint small down>
+          <span>render below 768</span>
+        </Breakpoint>
+      </BreakpointProvider>
     );
-    expect(wrapper.children()).toHaveLength(1);
+    expect(wrapper.children().children()).toHaveLength(1);
   });
 
   it('should render small up', () => {
-    const wrapper = shallow(
-      <Breakpoint small up>
-        <span>render above 576</span>
-      </Breakpoint>
+    const wrapper = mount(
+      <BreakpointProvider>
+        <Breakpoint small up>
+          <span>render above 576</span>
+        </Breakpoint>
+      </BreakpointProvider>
     );
-    expect(wrapper.children()).toHaveLength(1);
+    expect(wrapper.children().children()).toHaveLength(1);
   });
 
   it('should not render medium only', () => {
-    let wrapper = shallow(
-      <Breakpoint medium>
-        <span>should not render between 768 and 992</span>
-      </Breakpoint>
+    let wrapper = mount(
+      <BreakpointProvider>
+        <Breakpoint medium only>
+          <span>should not render between 768 and 992</span>
+        </Breakpoint>
+      </BreakpointProvider>
     );
-    expect(wrapper.children()).toHaveLength(0);
+    expect(wrapper.children().children()).toHaveLength(0);
   });
 
   it('should not render medium up', () => {
-    let wrapper = shallow(
-      <Breakpoint medium up>
-        <span>should not render above 768</span>
-      </Breakpoint>
+    let wrapper = mount(
+      <BreakpointProvider>
+        <Breakpoint medium up>
+          <span>should not render above 768</span>
+        </Breakpoint>
+      </BreakpointProvider>
     );
-    expect(wrapper.children()).toHaveLength(0);
+    expect(wrapper.children().children()).toHaveLength(0);
   });
 
   it('should render medium down', () => {
-    let wrapper = shallow(
-      <Breakpoint medium down>
-        <span>should render below 992</span>
-      </Breakpoint>
+    let wrapper = mount(
+      <BreakpointProvider>
+        <Breakpoint medium down>
+          <span>should render below 992</span>
+        </Breakpoint>
+      </BreakpointProvider>
     );
-    expect(wrapper.children()).toHaveLength(1);
+    expect(wrapper.children().children()).toHaveLength(1);
   });
 
   it('should not render large only', () => {
-    let wrapper = shallow(
-      <Breakpoint large only>
-        <span>should not render between 992 and 1200</span>
-      </Breakpoint>
+    let wrapper = mount(
+      <BreakpointProvider>
+        <Breakpoint large only>
+          <span>should not render between 992 and 1200</span>
+        </Breakpoint>
+      </BreakpointProvider>
     );
-    expect(wrapper.children()).toHaveLength(0);
+    expect(wrapper.children().children()).toHaveLength(0);
   });
 
   it('should not render large up', () => {
-    let wrapper = shallow(
-      <Breakpoint large up>
-        <span>should not render above 992</span>
-      </Breakpoint>
+    let wrapper = mount(
+      <BreakpointProvider>
+        <Breakpoint large up>
+          <span>should not render above 992</span>
+        </Breakpoint>
+      </BreakpointProvider>
     );
-    expect(wrapper.children()).toHaveLength(0);
+    expect(wrapper.children().children()).toHaveLength(0);
   });
 
   it('should render large down', () => {
-    let wrapper = shallow(
-      <Breakpoint large down>
-        <span>should render below 1200</span>
-      </Breakpoint>
+    let wrapper = mount(
+      <BreakpointProvider>
+        <Breakpoint large down>
+          <span>should render below 1200</span>
+        </Breakpoint>
+      </BreakpointProvider>
     );
-    expect(wrapper.children()).toHaveLength(1);
+    expect(wrapper.children().children()).toHaveLength(1);
   });
 
   afterEach(() => {
@@ -123,91 +143,111 @@ describe('Breakpoint - medium', () => {
   });
 
   it('should not render small only', () => {
-    let wrapper = shallow(
-      <Breakpoint small>
-        <span>should not render between 576 and 768</span>
-      </Breakpoint>
+    let wrapper = mount(
+      <BreakpointProvider>
+        <Breakpoint small>
+          <span>should not render between 576 and 768</span>
+        </Breakpoint>
+      </BreakpointProvider>
     );
-    expect(wrapper.children()).toHaveLength(0);
+    expect(wrapper.children().children()).toHaveLength(0);
   });
 
   it('should not render small down', () => {
-    const wrapper = shallow(
-      <Breakpoint small down>
-        <span>should not render below 768</span>
-      </Breakpoint>
+    const wrapper = mount(
+      <BreakpointProvider>
+        <Breakpoint small down>
+          <span>should not render below 768</span>
+        </Breakpoint>
+      </BreakpointProvider>
     );
-    expect(wrapper.children()).toHaveLength(0);
+    expect(wrapper.children().children()).toHaveLength(0);
   });
 
   it('should render small up', () => {
-    const wrapper = shallow(
-      <Breakpoint small up>
-        <span>should render above 576</span>
-      </Breakpoint>
+    const wrapper = mount(
+      <BreakpointProvider>
+        <Breakpoint small up>
+          <span>should render above 576</span>
+        </Breakpoint>
+      </BreakpointProvider>
     );
-    expect(wrapper.children()).toHaveLength(1);
+    expect(wrapper.children().children()).toHaveLength(1);
   });
 
   it('should render medium only', () => {
-    let wrapper = shallow(
-      <Breakpoint medium>
-        <span>should render between 768 and 992</span>
-      </Breakpoint>
+    let wrapper = mount(
+      <BreakpointProvider>
+        <Breakpoint medium>
+          <span>should render between 768 and 992</span>
+        </Breakpoint>
+      </BreakpointProvider>
     );
-    expect(wrapper.children()).toHaveLength(1);
+    expect(wrapper.children().children()).toHaveLength(1);
 
-    wrapper = shallow(
-      <Breakpoint medium only>
-        <span>should render between 768 and 992</span>
-      </Breakpoint>
+    wrapper = mount(
+      <BreakpointProvider>
+        <Breakpoint medium only>
+          <span>should render between 768 and 992</span>
+        </Breakpoint>
+      </BreakpointProvider>
     );
-    expect(wrapper.children()).toHaveLength(1);
+    expect(wrapper.children().children()).toHaveLength(1);
   });
 
   it('should render medium up', () => {
-    let wrapper = shallow(
-      <Breakpoint medium up>
-        <span>should render above 768</span>
-      </Breakpoint>
+    let wrapper = mount(
+      <BreakpointProvider>
+        <Breakpoint medium up>
+          <span>should render above 768</span>
+        </Breakpoint>
+      </BreakpointProvider>
     );
-    expect(wrapper.children()).toHaveLength(1);
+    expect(wrapper.children().children()).toHaveLength(1);
   });
 
   it('should render medium down', () => {
-    let wrapper = shallow(
-      <Breakpoint medium down>
-        <span>should render below 992</span>
-      </Breakpoint>
+    let wrapper = mount(
+      <BreakpointProvider>
+        <Breakpoint medium down>
+          <span>should render below 992</span>
+        </Breakpoint>
+      </BreakpointProvider>
     );
-    expect(wrapper.children()).toHaveLength(1);
+    expect(wrapper.children().children()).toHaveLength(1);
   });
 
   it('should not render large only', () => {
-    let wrapper = shallow(
-      <Breakpoint large only>
-        <span>should not render between 992 and 1200</span>
-      </Breakpoint>
+    let wrapper = mount(
+      <BreakpointProvider>
+        <Breakpoint large only>
+          <span>should not render between 992 and 1200</span>
+        </Breakpoint>
+      </BreakpointProvider>
     );
-    expect(wrapper.children()).toHaveLength(0);
+    expect(wrapper.children().children()).toHaveLength(0);
   });
 
   it('should not render large up', () => {
-    let wrapper = shallow(
-      <Breakpoint large up>
-        <span>should not render above 992</span>
-      </Breakpoint>
+    let wrapper = mount(
+      <BreakpointProvider>
+        <Breakpoint large up>
+          <span>should not render above 992</span>
+        </Breakpoint>
+      </BreakpointProvider>
     );
-    expect(wrapper.children()).toHaveLength(0);
+    expect(wrapper.children().children()).toHaveLength(0);
   });
 
   it('should render large down', () => {
-    let wrapper = shallow(
-      <Breakpoint large down>
-        <span>should render below 1200</span>
-      </Breakpoint>
+    let wrapper = mount(
+      <BreakpointProvider>
+        <Breakpoint large down>
+          <span>should render below 1200</span>
+        </Breakpoint>
+      </BreakpointProvider>
     );
-    expect(wrapper.children()).toHaveLength(1);
+    expect(wrapper.children().children()).toHaveLength(1);
   });
 
   afterEach(() => {
@@ -225,91 +265,111 @@ describe('Breakpoint - large', () => {
   });
 
   it('should not render small only', () => {
-    let wrapper = shallow(
-      <Breakpoint small>
-        <span>should not render between 576 and 768</span>
-      </Breakpoint>
+    let wrapper = mount(
+      <BreakpointProvider>
+        <Breakpoint small>
+          <span>should not render between 576 and 768</span>
+        </Breakpoint>
+      </BreakpointProvider>
     );
-    expect(wrapper.children()).toHaveLength(0);
+    expect(wrapper.children().children()).toHaveLength(0);
   });
 
   it('should not render small down', () => {
-    const wrapper = shallow(
-      <Breakpoint small down>
-        <span>should not render below 768</span>
-      </Breakpoint>
+    const wrapper = mount(
+      <BreakpointProvider>
+        <Breakpoint small down>
+          <span>should not render below 768</span>
+        </Breakpoint>
+      </BreakpointProvider>
     );
-    expect(wrapper.children()).toHaveLength(0);
+    expect(wrapper.children().children()).toHaveLength(0);
   });
 
   it('should render small up', () => {
-    const wrapper = shallow(
-      <Breakpoint small up>
-        <span>should render above 576</span>
-      </Breakpoint>
+    const wrapper = mount(
+      <BreakpointProvider>
+        <Breakpoint small up>
+          <span>should render above 576</span>
+        </Breakpoint>
+      </BreakpointProvider>
     );
-    expect(wrapper.children()).toHaveLength(1);
+    expect(wrapper.children().children()).toHaveLength(1);
   });
 
   it('should not render medium only', () => {
-    let wrapper = shallow(
-      <Breakpoint medium>
-        <span>should not render between 768 and 768</span>
-      </Breakpoint>
+    let wrapper = mount(
+      <BreakpointProvider>
+        <Breakpoint medium>
+          <span>should not render between 768 and 768</span>
+        </Breakpoint>
+      </BreakpointProvider>
     );
-    expect(wrapper.children()).toHaveLength(0);
+    expect(wrapper.children().children()).toHaveLength(0);
   });
 
   it('should render medium up', () => {
-    let wrapper = shallow(
-      <Breakpoint medium up>
-        <span>should render above 768</span>
-      </Breakpoint>
+    let wrapper = mount(
+      <BreakpointProvider>
+        <Breakpoint medium up>
+          <span>should render above 768</span>
+        </Breakpoint>
+      </BreakpointProvider>
     );
-    expect(wrapper.children()).toHaveLength(1);
+    expect(wrapper.children().children()).toHaveLength(1);
   });
 
   it('should not render medium down', () => {
-    let wrapper = shallow(
-      <Breakpoint medium down>
-        <span>should not render below 768</span>
-      </Breakpoint>
+    let wrapper = mount(
+      <BreakpointProvider>
+        <Breakpoint medium down>
+          <span>should not render below 768</span>
+        </Breakpoint>
+      </BreakpointProvider>
     );
-    expect(wrapper.children()).toHaveLength(0);
+    expect(wrapper.children().children()).toHaveLength(0);
   });
 
   it('should render large only', () => {
-    let wrapper = shallow(
-      <Breakpoint large only>
-        <span>should render between 992 and 1200</span>
-      </Breakpoint>
+    let wrapper = mount(
+      <BreakpointProvider>
+        <Breakpoint large only>
+          <span>should render between 992 and 1200</span>
+        </Breakpoint>
+      </BreakpointProvider>
     );
-    expect(wrapper.children()).toHaveLength(1);
+    expect(wrapper.children().children()).toHaveLength(1);
 
-    wrapper = shallow(
-      <Breakpoint large>
-        <span>should render between 992 and 1200</span>
-      </Breakpoint>
+    wrapper = mount(
+      <BreakpointProvider>
+        <Breakpoint large>
+          <span>should render between 992 and 1200</span>
+        </Breakpoint>
+      </BreakpointProvider>
     );
-    expect(wrapper.children()).toHaveLength(1);
+    expect(wrapper.children().children()).toHaveLength(1);
   });
 
   it('should render large up', () => {
-    let wrapper = shallow(
-      <Breakpoint large up>
-        <span>should render above 992</span>
-      </Breakpoint>
+    let wrapper = mount(
+      <BreakpointProvider>
+        <Breakpoint large up>
+          <span>should render above 992</span>
+        </Breakpoint>
+      </BreakpointProvider>
     );
-    expect(wrapper.children()).toHaveLength(1);
+    expect(wrapper.children().children()).toHaveLength(1);
   });
 
   it('should render large down', () => {
-    let wrapper = shallow(
-      <Breakpoint large down>
-        <span>should render below 1200</span>
-      </Breakpoint>
+    let wrapper = mount(
+      <BreakpointProvider>
+        <Breakpoint large down>
+          <span>should render below 1200</span>
+        </Breakpoint>
+      </BreakpointProvider>
     );
-    expect(wrapper.children()).toHaveLength(1);
+    expect(wrapper.children().children()).toHaveLength(1);
   });
 
   afterEach(() => {

--- a/src/Breakpoint/BreakpointProvider.js
+++ b/src/Breakpoint/BreakpointProvider.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import BreakpointUtil from './breakpoint-util';
+
+const BreakpointContext = React.createContext();
+
+export default class BreakpointProvider extends React.Component {
+  constructor(props) {
+    super(props);
+    const currentWidth = BreakpointUtil.currentWidth;
+
+    this.state = {
+      currentWidth: currentWidth,
+      currentBreakpointName: BreakpointUtil.getBreakpointName(currentWidth)
+    };
+
+    this.handleResize = this.handleResize.bind(
+      this
+    );
+  }
+
+  componentDidMount() {
+    window.addEventListener('resize', this.handleResize);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.handleResize);
+  }
+
+  handleResize() {
+    const currentWidth = BreakpointUtil.currentWidth;
+
+    this.setState({
+      currentWidth: currentWidth,
+      currentBreakpointName: BreakpointUtil.getBreakpointName(currentWidth)
+    });
+  }
+
+  render() {
+    const { children } = this.props;
+    const { currentWidth, currentBreakpointName } = this.state;
+
+    return (
+      <BreakpointContext.Provider
+        value={{
+          currentWidth,
+          currentBreakpointName,
+        }}
+      >
+        { children }
+      </BreakpointContext.Provider>
+    );
+  }
+}
+
+BreakpointProvider.propTypes = {
+  children: PropTypes.node,
+};
+
+export {
+  BreakpointContext,
+}

--- a/src/Breakpoint/BreakpointProvider.test.js
+++ b/src/Breakpoint/BreakpointProvider.test.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import { shallow  } from 'enzyme';
+import { BreakpointProvider } from 'index';
+import { BreakpointUtil } from './breakpoint-util';
+import sinon from 'sinon';
+
+describe('Breakpoint Context Provider', () => {
+  it('render without crashing', () => {
+    const wrapper = shallow(<BreakpointProvider>Hello World</BreakpointProvider>);
+    expect(wrapper).toHaveLength(1);
+    expect(wrapper.text()).toEqual('Hello World');
+  });
+});
+
+describe('Breakpoint - large', () => {
+  let currWidthStub;
+  let currBPointNameStub;
+
+  beforeEach(() => {
+    currWidthStub = sinon.stub(BreakpointUtil.prototype, 'currentWidth').get(function getterFn() {
+      return 1024;
+    });
+
+    currBPointNameStub = sinon.stub(BreakpointUtil.prototype, 'getBreakpointName').returns('large');
+  });
+
+  it('should pass the correct value', () => {
+    const wrapper = shallow(<BreakpointProvider>Hello World</BreakpointProvider>);
+    expect(wrapper).toHaveLength(1);
+    expect(wrapper.prop('value')).toEqual({
+      currentWidth: 1024,
+      currentBreakpointName: 'large',
+    });
+  });
+
+  it('should set correct state', () => {
+    let wrapper = shallow(
+      <BreakpointProvider>
+      </BreakpointProvider>
+    );
+    expect(wrapper.state()).toEqual({
+      currentWidth: 1024,
+      currentBreakpointName: 'large',
+    });
+
+    currBPointNameStub.restore();
+    currBPointNameStub = sinon.stub(BreakpointUtil.prototype, 'getBreakpointName').returns('small');
+
+    global.dispatchEvent(new Event('resize'));
+
+    expect(wrapper.state()).toEqual({
+      currentWidth: 1024,
+      currentBreakpointName: 'small',
+    });
+  });
+
+  afterEach(() => {
+    currWidthStub.restore();
+    currBPointNameStub.restore();
+  });
+});

--- a/src/Breakpoint/breakpoint-util.js
+++ b/src/Breakpoint/breakpoint-util.js
@@ -14,8 +14,7 @@ export class BreakpointUtil {
     return this.getWidthSafely();
   }
 
-  get currentBreakpointName() {
-    const width = this.getWidthSafely();
+  getBreakpointName(width) {
     let bpName;
 
     this.allBreakpoints.forEach((obj) => {
@@ -63,15 +62,15 @@ export class BreakpointUtil {
     return nextBreakpointWidth;
   }
 
-  shouldRender({ breakpointName, modifier }) {
+  shouldRender({ breakpointName, modifier, currentBreakpointName, currentWidth }) {
     if (modifier === 'only') {
-      if (breakpointName === this.currentBreakpointName) return true;
+      if (breakpointName === currentBreakpointName) return true;
     } else if (modifier === 'up') {
       const breakpointWidth = this.getBreakpointWidth(breakpointName);
-      if (this.currentWidth >= breakpointWidth) return true;
+      if (currentWidth >= breakpointWidth) return true;
     } else if (modifier === 'down') {
       const nextBreakpointWidth = this.getNextBreakpointWidth(breakpointName);
-      if (this.currentWidth < nextBreakpointWidth) return true;
+      if (currentWidth < nextBreakpointWidth) return true;
     }
 
     return false;

--- a/src/Breakpoint/index.js
+++ b/src/Breakpoint/index.js
@@ -1,2 +1,4 @@
 import Breakpoint from './Breakpoint';
-export default Breakpoint;
+import BreakpointProvider from './BreakpointProvider';
+
+export { Breakpoint, BreakpointProvider };

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,2 @@
-import Breakpoint from './Breakpoint';
+export { Breakpoint, BreakpointProvider } from './Breakpoint';
 export { setDefaultBreakpoints } from './Breakpoint/breakpoint-util';
-
-export default Breakpoint;


### PR DESCRIPTION
This PR aims to reduce the number of event listeners across the app.
With the current implementation, every `Breakpoint` instance adds a window resize listener, which may hurt performance.

Using the new React 16 Context API, we can add a single resize listener in the Context Provider and store the current breakpoint value in a single point, using the Breakpoint Util just for width-related logic (and not for storing state).

I also added some changes to the Readme, since the user now has to wrap the component with a `BreakpointProvider`.

The biggest changes were on the unit tests: unfortunately enzyme's `shallowWrapper` doesn't support the new React context API (see [here](https://github.com/airbnb/enzyme/issues/1913) and [here](https://github.com/airbnb/enzyme/issues/1553)). So I had to use `mount` in order to pass a context to the `Breakpoint` component being tested.

Feel free to comment — as I know it's a considerable change to the code — :-)

