### PR TITLE
Add support for custom tagName & className

### DIFF
--- a/src/Breakpoint/Breakpoint.js
+++ b/src/Breakpoint/Breakpoint.js
@@ -16,24 +16,30 @@ export default class Breakpoint extends React.Component {
   extractBreakpointAndModifierFromProps(allProps) {
     let breakpoint;
     let modifier;
+    let tagName = allProps.tagName || 'div'
+    let className = allProps.className || ''
+
     Object.keys(allProps).forEach((prop) => {
       if (prop === 'up' || prop === 'down' || prop === 'only') {
         modifier = prop;
-      } else {
+      } else if(prop !== 'tagName' && prop !== 'className') {
         breakpoint = prop;
       }
     });
 
-    if (!modifier) modifier = 'only';
+    if (!modifier)  modifier  = 'only';
+
     return {
       breakpoint,
-      modifier
+      modifier,
+      tagName,
+      className
     };
   }
 
   render() {
     const { children, ...rest } = this.props;
-    const { breakpoint, modifier } = this.extractBreakpointAndModifierFromProps(
+    const { breakpoint, modifier, className, tagName } = this.extractBreakpointAndModifierFromProps(
       rest
     );
     const { currentBreakpointName, currentWidth } = this.context;
@@ -47,8 +53,9 @@ export default class Breakpoint extends React.Component {
 
     if (!shouldRender) return null;
 
+    const Tag = tagName
     return (
-      <div className={`breakpoint__${breakpoint}-${modifier}`}>{children}</div>
+      <Tag className={`breakpoint__${breakpoint}-${modifier} ${className}`}>{children}</Tag>
     );
   }
 }
@@ -60,5 +67,7 @@ Breakpoint.propTypes = {
   up: PropTypes.bool,
   down: PropTypes.bool,
   only: PropTypes.bool,
+  tagName: PropTypes.string,
+  className: PropTypes.string,
 };
 

--- a/src/Breakpoint/Breakpoint.test.js
+++ b/src/Breakpoint/Breakpoint.test.js
@@ -372,6 +372,39 @@ describe('Breakpoint - large', () => {
     expect(wrapper.children().children()).toHaveLength(1);
   });
 
+  it('should render as a span', () => {
+    let wrapper = mount(
+      <BreakpointProvider>
+        <Breakpoint large tagName="span">
+          <span>parent should be a span</span>
+        </Breakpoint>
+      </BreakpointProvider>
+    );
+    expect(wrapper.children().children().type()).toEqual('span')
+  })
+
+  it('should render as an a', () => {
+    let wrapper = mount(
+      <BreakpointProvider>
+        <Breakpoint large tagName="a">
+          <span>parent should be an a</span>
+        </Breakpoint>
+      </BreakpointProvider>
+    );
+    expect(wrapper.children().children().type()).toEqual('a')
+  })
+
+  it('should have className "test"', () => {
+    let wrapper = mount(
+      <BreakpointProvider>
+        <Breakpoint large className="test">
+          <span>parent should have className test</span>
+        </Breakpoint>
+      </BreakpointProvider>
+    );
+    expect(wrapper.children().children().hasClass('test')).toEqual(true)
+  })
+
   afterEach(() => {
     widthStub.restore();
   });


### PR DESCRIPTION
Breakpoint component takes tagName (string, default 'div') and className (string, default '') as props and passes them to the rendered breakpoint wrapper. Useful e.g. for tables with responsive td's.