### PR TITLE
Accessing current width and current breakpoint name

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ const Example = () => {
 
 - [setDefaultBreakpoints](#set-default-breakpoints)
 - [Breakpoint](#breakpoint)
+- [getCurrentWidth](#get-current-width)
 
 ### Set Default Breakpoints
 
@@ -155,6 +156,23 @@ You have **three** modifiers
 - **up** - will render the component **in** the specified breakpoint and all the breakpoints **above** it (greater than the width).
 
 - **down** - will render the component **in** the specified breakpoint and all the breakpoints **below** it (less than the width).
+
+### Get Current Width
+
+To access current width directly, call react hook `getCurrentWidth` in the render function of a functional component:
+
+```jsx
+import { getCurrentWidth } from 'react-socks'
+
+const CustomComponent = () => {
+  const width = getCurrentWidth()
+  if (width < 500) {
+    return <h1>Hello!</h1>
+  } else {
+    return <h2>Hello!</h2>
+  }
+}
+```
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ const Example = () => {
 
 - [setDefaultBreakpoints](#set-default-breakpoints)
 - [Breakpoint](#breakpoint)
-- [getCurrentWidth](#get-current-width)
+- [getCurrentWidth](#get-current-width-current-breakpoint-name) / [getCurrentBreakpointName](#get-current-width-current-breakpoint-name)
 
 ### Set Default Breakpoints
 
@@ -157,9 +157,9 @@ You have **three** modifiers
 
 - **down** - will render the component **in** the specified breakpoint and all the breakpoints **below** it (less than the width).
 
-### Get Current Width
+### Get Current Width / Breakpoint Name
 
-To access current width directly, call react hook `getCurrentWidth` in the render function of a functional component:
+You can access current width directly, if you call `getCurrentWidth` in the render function of a functional component
 
 ```jsx
 import { getCurrentWidth } from 'react-socks'
@@ -167,6 +167,21 @@ import { getCurrentWidth } from 'react-socks'
 const CustomComponent = () => {
   const width = getCurrentWidth()
   if (width < 500) {
+    return <h1>Hello!</h1>
+  } else {
+    return <h2>Hello!</h2>
+  }
+}
+```
+
+You can get current breakpoint name with `getCurrentBreakpointName`:
+
+```jsx
+import { getCurrentBreakpointName } from 'react-socks'
+
+const CustomComponent = () => {
+  const breakpoint = getCurrentBreakpointName()
+  if (breakpoint == 'small') {
     return <h1>Hello!</h1>
   } else {
     return <h2>Hello!</h2>

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ const Example = () => {
 
 - [setDefaultBreakpoints](#set-default-breakpoints)
 - [Breakpoint](#breakpoint)
-- [getCurrentWidth](#get-current-width-current-breakpoint-name) / [getCurrentBreakpointName](#get-current-width-current-breakpoint-name)
+- [getCurrentWidth](#get-current-width--breakpoint-name) / [getCurrentBreakpointName](#get-current-width--breakpoint-name)
 
 ### Set Default Breakpoints
 
@@ -159,7 +159,7 @@ You have **three** modifiers
 
 ### Get Current Width / Breakpoint Name
 
-You can access current width directly, if you call `getCurrentWidth` in the render function of a functional component
+Ff you call `getCurrentWidth` in the render function of a functional component, you can access current width directly:
 
 ```jsx
 import { getCurrentWidth } from 'react-socks'

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ You have **three** modifiers
 
 ### Get Current Width / Breakpoint Name
 
-Ff you call `getCurrentWidth` in the render function of a functional component, you can access current width directly:
+If you call `getCurrentWidth` in the render function, you can access the current width directly:
 
 ```jsx
 import { getCurrentWidth } from 'react-socks'
@@ -174,7 +174,7 @@ const CustomComponent = () => {
 }
 ```
 
-You can get current breakpoint name with `getCurrentBreakpointName`:
+You can also get the current breakpoint name with `getCurrentBreakpointName`:
 
 ```jsx
 import { getCurrentBreakpointName } from 'react-socks'
@@ -188,6 +188,8 @@ const CustomComponent = () => {
   }
 }
 ```
+
+These two functions are calling `React.useContext()`, so there are only working in functional components.
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ const Example = () => {
 
 - [setDefaultBreakpoints](#set-default-breakpoints)
 - [Breakpoint](#breakpoint)
-- [getCurrentWidth](#get-current-width--breakpoint-name) / [getCurrentBreakpointName](#get-current-width--breakpoint-name)
+- [useCurrentWidth](#use-current-width--breakpoint-name) / [useCurrentBreakpointName](#use-current-width--breakpoint-name)
 
 ### Set Default Breakpoints
 
@@ -157,15 +157,15 @@ You have **three** modifiers
 
 - **down** - will render the component **in** the specified breakpoint and all the breakpoints **below** it (less than the width).
 
-### Get Current Width / Breakpoint Name
+### Use Current Width / Breakpoint Name
 
-If you call `getCurrentWidth` in the render function, you can access the current width directly:
+If you call `useCurrentWidth` in the render function, you can access the current width directly:
 
 ```jsx
-import { getCurrentWidth } from 'react-socks'
+import { useCurrentWidth } from 'react-socks'
 
 const CustomComponent = () => {
-  const width = getCurrentWidth()
+  const width = useCurrentWidth()
   if (width < 500) {
     return <h1>Hello!</h1>
   } else {
@@ -174,13 +174,13 @@ const CustomComponent = () => {
 }
 ```
 
-You can also get the current breakpoint name with `getCurrentBreakpointName`:
+You can also use the current breakpoint name with `useCurrentBreakpointName`:
 
 ```jsx
-import { getCurrentBreakpointName } from 'react-socks'
+import { useCurrentBreakpointName } from 'react-socks'
 
 const CustomComponent = () => {
-  const breakpoint = getCurrentBreakpointName()
+  const breakpoint = useCurrentBreakpointName()
   if (breakpoint == 'small') {
     return <h1>Hello!</h1>
   } else {
@@ -188,8 +188,6 @@ const CustomComponent = () => {
   }
 }
 ```
-
-These two functions are calling `React.useContext()`, so there are only working in functional components.
 
 ## Contributors
 

--- a/src/Breakpoint/BreakpointProvider.js
+++ b/src/Breakpoint/BreakpointProvider.js
@@ -57,11 +57,11 @@ export default class BreakpointProvider extends React.Component {
   }
 }
 
-export const getCurrentWidth = () => {
+export const useCurrentWidth = () => {
   return React.useContext(BreakpointContext).currentWidth
 }
 
-export const getCurrentBreakpointName = () => {
+export const useCurrentBreakpointName = () => {
   return React.useContext(BreakpointContext).currentBreakpointName
 }
 

--- a/src/Breakpoint/BreakpointProvider.js
+++ b/src/Breakpoint/BreakpointProvider.js
@@ -61,6 +61,10 @@ export const getCurrentWidth = () => {
   return React.useContext(BreakpointContext).currentWidth
 }
 
+export const getCurrentBreakpointName = () => {
+  return React.useContext(BreakpointContext).currentBreakpointName
+}
+
 BreakpointProvider.propTypes = {
   children: PropTypes.node,
 };

--- a/src/Breakpoint/BreakpointProvider.js
+++ b/src/Breakpoint/BreakpointProvider.js
@@ -57,6 +57,10 @@ export default class BreakpointProvider extends React.Component {
   }
 }
 
+export const getCurrentWidth = () => {
+  return React.useContext(BreakpointContext).currentWidth
+}
+
 BreakpointProvider.propTypes = {
   children: PropTypes.node,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import { Breakpoint, BreakpointProvider } from './Breakpoint';
 import { setDefaultBreakpoints } from './Breakpoint/breakpoint-util';
-import { getCurrentWidth, getCurrentBreakpointName } from './Breakpoint/BreakpointProvider';
+import { useCurrentWidth, useCurrentBreakpointName } from './Breakpoint/BreakpointProvider';
 
 export default Breakpoint;
-export { Breakpoint, BreakpointProvider, setDefaultBreakpoints, getCurrentWidth, getCurrentBreakpointName };
+export { Breakpoint, BreakpointProvider, setDefaultBreakpoints, useCurrentWidth, useCurrentBreakpointName };

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import { Breakpoint, BreakpointProvider } from './Breakpoint';
 import { setDefaultBreakpoints } from './Breakpoint/breakpoint-util';
+import { getCurrentWidth } from './Breakpoint/BreakpointProvider';
 
 export default Breakpoint;
-export { Breakpoint, BreakpointProvider, setDefaultBreakpoints };
+export { Breakpoint, BreakpointProvider, setDefaultBreakpoints, getCurrentWidth };

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import { Breakpoint, BreakpointProvider } from './Breakpoint';
 import { setDefaultBreakpoints } from './Breakpoint/breakpoint-util';
-import { getCurrentWidth } from './Breakpoint/BreakpointProvider';
+import { getCurrentWidth, getCurrentBreakpointName } from './Breakpoint/BreakpointProvider';
 
 export default Breakpoint;
-export { Breakpoint, BreakpointProvider, setDefaultBreakpoints, getCurrentWidth };
+export { Breakpoint, BreakpointProvider, setDefaultBreakpoints, getCurrentWidth, getCurrentBreakpointName };


### PR DESCRIPTION
Sometimes it's useful to access context variables directly, e.g. if you want to write your own logic (in conjunction with react-socks).

Implementing it with react hooks is quite straight forward, here is a PR.