### PR TITLE
docs: Update README for not importing default Breakpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Just wrap your top level component with `BreakpointProvider` and use the `Breakp
 _Note: `BreakpointProvider` was introduced only in `v1.0.0`. It's not available in previous alpha versions._
 
 ```jsx
-import Breakpoint, { BreakpointProvider } from 'react-socks';
+import  { Breakpoint, BreakpointProvider } from 'react-socks';
 
 // entry file (usually App.js or index.js)
 const App = () => (


### PR DESCRIPTION
We should avoid default export for TS. [see here](https://basarat.gitbooks.io/typescript/content/docs/tips/defaultIsBad.html).

To align both ESM and TS users, we can update our example by avoiding default export.