### PR TITLE
Feature: Support for custom breakpoints

### DIFF
--- a/examples/Example.js
+++ b/examples/Example.js
@@ -57,6 +57,21 @@ class Example extends React.Component {
               Hello World! xlarge only
             </div>
           </Breakpoint>
+          <Breakpoint customQuery="(min-width: 500px)">
+            <div style={{backgroundColor: 'red' }}>
+              Custom breakpoint: (min-width : 500px)
+            </div>
+          </Breakpoint>
+          <Breakpoint customQuery="(max-width: 1000px)">
+            <div style={{backgroundColor: 'yellow' }}>
+              Custom breakpoint: (max-width : 1000px)
+            </div>
+          </Breakpoint>
+          <Breakpoint customQuery="(min-width: 500px) and (max-width: 700px)">
+            <div style={{backgroundColor: 'lightblue' }}>
+              Custom breakpoint: (min-width : 500px) && (max-width : 700px)
+            </div>
+          </Breakpoint>
         </div>
       </BreakpointProvider>
     );

--- a/src/Breakpoint/Breakpoint.js
+++ b/src/Breakpoint/Breakpoint.js
@@ -16,34 +16,48 @@ export default class Breakpoint extends React.Component {
   extractBreakpointAndModifierFromProps(allProps) {
     let breakpoint;
     let modifier;
-    let tagName = allProps.tagName || 'div'
-    let className = allProps.className || ''
-    let style = allProps.style
+    let tagName = allProps.tagName || 'div';
+    let className = allProps.className || '';
+    let style = allProps.style;
+    let usesCustomQuery = false;
 
     Object.keys(allProps).forEach((prop) => {
       if (prop === 'up' || prop === 'down' || prop === 'only') {
         modifier = prop;
-      } else if(prop !== 'tagName' && prop !== 'className' && prop !== 'style') {
+      } else if (prop === 'customQuery') {
+        usesCustomQuery = true;
+      } else if (prop !== 'tagName' && prop !== 'className' && prop !== 'style') {
         breakpoint = prop;
-      }
+      } 
     });
 
-    if (!modifier)  modifier  = 'only';
+    if (modifier === 'up' || modifier === 'down' || modifier === 'only') {
+      usesCustomQuery = false;
+    }
+
+    if (!modifier && !usesCustomQuery)  modifier  = 'only';
 
     return {
       breakpoint,
       modifier,
       tagName,
       className,
-      style
+      style,
+      customQuery: usesCustomQuery ? allProps.customQuery : null
     };
   }
 
   render() {
     const { children, ...rest } = this.props;
-    const { breakpoint, modifier, className, tagName, style } = this.extractBreakpointAndModifierFromProps(
-      rest
-    );
+    const { 
+      breakpoint, 
+      modifier, 
+      className, 
+      tagName, 
+      style, 
+      customQuery
+    } = this.extractBreakpointAndModifierFromProps(rest);
+
     const { currentBreakpointName, currentWidth } = this.context;
 
     const shouldRender = BreakpointUtil.shouldRender({
@@ -51,6 +65,7 @@ export default class Breakpoint extends React.Component {
       modifier,
       currentBreakpointName,
       currentWidth,
+      customQuery
     });
 
     if (!shouldRender) return null;
@@ -74,6 +89,6 @@ Breakpoint.propTypes = {
   style: PropTypes.objectOf(PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.number,
-  ]))
+  ])),
+  customQuery: PropTypes.string
 };
-

--- a/src/Breakpoint/breakpoint-util.js
+++ b/src/Breakpoint/breakpoint-util.js
@@ -64,7 +64,7 @@ export class BreakpointUtil {
     return nextBreakpointWidth;
   }
 
-  shouldRender({ breakpointName, modifier, currentBreakpointName, currentWidth }) {
+  shouldRender({ breakpointName, modifier, currentBreakpointName, currentWidth, customQuery }) {
     if (modifier === 'only') {
       if (breakpointName === currentBreakpointName) return true;
     } else if (modifier === 'up') {
@@ -73,8 +73,9 @@ export class BreakpointUtil {
     } else if (modifier === 'down') {
       const nextBreakpointWidth = this.getNextBreakpointWidth(breakpointName);
       if (currentWidth < nextBreakpointWidth) return true;
+    } else if (customQuery) {
+      return window.matchMedia(customQuery).matches;
     }
-
     return false;
   }
 


### PR DESCRIPTION
- Pass custom media queries as string with `customQuery`.
- If any of those usual properties are set, `customQuery` will not be honoured.
- Note: `window.matchMedia()` is supported in all major browsers.